### PR TITLE
Error in package.json: Missing a comma(,)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint": "^8.57.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
-    "prettier": "^3.3.2"
+    "prettier": "^3.3.2",
     "typescript": "^5.2.2",
     "vite": "^5.2.0"
   },


### PR DESCRIPTION
# Issue Number
This is what I encountered while I was cloning the repo onto my local for solving other issues.

# Type of Change
- [x] Bug fix (non-breaking change which fixes an issue) / Syntax Error fixed

# Details
I was interested in solving the [DESIGN] issues raised in the issues tab. So, I was cloning the repository onto my local.
As soon as I hit the `npm install` command I got  an error:
![image](https://github.com/user-attachments/assets/db21187a-0d5d-477c-92d5-6fae5fbff4f5)

So I opened the package.json and noticed a comma (,) missing from the `devDependencies` line no. 36 (prettier line).
![image](https://github.com/user-attachments/assets/c216031a-fad7-4b6b-8daa-493b028267a8)


# Screenshots
Corrected the syntax:
![image](https://github.com/user-attachments/assets/9a43ff20-85ee-48a1-a75e-943a120dcf2c)

And now `npm install` works fine.
![image](https://github.com/user-attachments/assets/b8326fe5-a613-4390-bcff-9716508d29bc)

# How Has This Been Tested?
It was a small syntax error, which has been fixed. No further test was needed according to me.

# Checklist
- [x] Code is formatted in line with the style guidelines

@VivianWilde @na933950 please review the PR and merge it to avoid many people facing this issue.
Thanks!
